### PR TITLE
Cleaned up error message related to predicate arguments

### DIFF
--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -47,7 +47,7 @@ Optional<PredicateDecl> Parser::parsePredicateDecl() {
                 parameters.push_back(param);
             } else {
                 if (parameters.size() == 0) {
-                    emitSyntaxError("Empty parentheses should not be included for predicates with no arguments.")
+                    emitSyntaxError("Empty parentheses should not be included for predicates with no arguments.");
                 } else {
                     emitSyntaxError("Expected an additional argument after \",\" in parameter list.");
                 }

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -32,6 +32,7 @@ Optional<PredicateDecl> Parser::parsePredicateDecl() {
     };
 
     if(identifier.type != Token::Type::identifier) {
+        emitSyntaxError("Expected predicate name in predicate definition.");
         return rewindAndReturn();
     }
 
@@ -364,7 +365,6 @@ Optional<Predicate> Parser::parsePredicate() {
     }
 
     if(parsePredicateDecl().unwrapGuard(decl)) {
-        emitSyntaxError("Expected predicate name in predicate definition.");
         return rewindAndReturn();
     }
 

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -48,7 +48,7 @@ Optional<PredicateDecl> Parser::parsePredicateDecl() {
                 parameters.push_back(param);
             } else {
                 if (parameters.size() == 0) {
-                    emitSyntaxError("Empty parentheses should not be included for predicates with no arguments.");
+                    emitSyntaxError("Parentheses must not appear after predicate name for predicates with zero arguments.");
                 } else {
                     emitSyntaxError("Expected an additional argument after \",\" in parameter list.");
                 }

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -46,7 +46,12 @@ Optional<PredicateDecl> Parser::parsePredicateDecl() {
             if(parseParameter().unwrapInto(param)) {
                 parameters.push_back(param);
             } else {
-                emitSyntaxError("Expected an additional argument after \",\" in parameter list.");
+                if (parameters.size() == 0) {
+                    emitSyntaxError("Empty parentheses should not be included for predicates with no arguments.")
+                } else {
+                    emitSyntaxError("Expected an additional argument after \",\" in parameter list.");
+                }
+
                 return rewindAndReturn();
             }
         } while(lexer.take(Token::Type::comma));
@@ -263,7 +268,7 @@ Optional<Expression> Parser::parseAtom() {
     // <atom> := <truth-literal>
     if(parseTruthLiteral().unwrapInto(tl)) {
         return Optional(Expression(tl));
-    
+
     // <atom> := <predicate-name>
     } else if(parsePredicateRef().unwrapInto(p)) {
         return Optional(Expression(p));


### PR DESCRIPTION
- Added "Parentheses must not appear after predicate name for predicates with zero arguments." syntax error for predicates that attempt to use "pred name()" syntax
- "Expected predicate name in predicate definition" error message no longer appears when a syntax error occurs during predicate argument parsing