### PR TITLE
Prevent multiple definitions of the same predicate

### DIFF
--- a/allium/include/SemAna/StaticError.h
+++ b/allium/include/SemAna/StaticError.h
@@ -36,6 +36,10 @@ enum class ErrorMessage {
 
     int_literal_not_convertible,
     predicate_argument_count,
+
+    /// A predicate was defined multiple times.
+    predicate_redefined,
+
     string_literal_not_convertible,
     type_redefined,
     undefined_predicate,

--- a/allium/lib/SemAna/Predicates.cpp
+++ b/allium/lib/SemAna/Predicates.cpp
@@ -50,6 +50,22 @@ public:
     }
 
     Optional<TypedAST::PredicateDecl> visit(const PredicateDecl &pd) {
+        const auto originalDeclaration = std::find_if(
+            ast.predicates.begin(),
+            ast.predicates.end(),
+            [&](Predicate p) {
+                return p.name.name == pd.name;
+            });
+
+        if(originalDeclaration->name.location != pd.location) {
+            error.emit(
+                pd.location,
+                ErrorMessage::predicate_redefined,
+                pd.name.string(),
+                originalDeclaration->name.location.toString());
+            return Optional<TypedAST::PredicateDecl>();
+        }
+
         return both(
             fullMap<Parameter, TypedAST::Parameter>(
                 pd.parameters,

--- a/allium/lib/SemAna/StaticError.cpp
+++ b/allium/lib/SemAna/StaticError.cpp
@@ -29,6 +29,8 @@ std::string formatString(ErrorMessage msg) {
         return "An Int literal is not convertible to type \"%s\".";
     case ErrorMessage::predicate_argument_count:
         return "Predicate \"%s\" expects %s arguments.";
+    case ErrorMessage::predicate_redefined:
+        return "Predicate \"%s\" was already defined at %s and cannot be redefined.";
     case ErrorMessage::string_literal_not_convertible:
         return "A string literal is not convertible to type \"%s\".";
     case ErrorMessage::type_redefined:

--- a/allium/unittests/TestSema.cpp
+++ b/allium/unittests/TestSema.cpp
@@ -250,6 +250,28 @@ TEST_F(TestSemAnaPredicates, predicate_argument_type_mismatch) {
     checkAll(AST(ts, {}, ps), error);
 }
 
+TEST_F(TestSemAnaPredicates, predicate_redefined) {
+    // pred p {}
+    // pred p {}
+
+    SourceLocation originalLocation(1, 5);
+    SourceLocation errorLocation(2, 5);
+    std::vector<Predicate> ps = {
+        Predicate(
+            PredicateDecl("p", {}, {}, originalLocation),
+            {}
+        ),
+        Predicate(
+            PredicateDecl("p", {}, {}, errorLocation),
+            {}
+        )
+    };
+
+    EXPECT_CALL(error, emit(errorLocation, ErrorMessage::predicate_redefined, "p", originalLocation.toString()));
+
+    checkAll(AST({}, {}, ps), error);
+}
+
 TEST_F(TestSemAnaPredicates, existential_variable_as_input_only_parameter) {
     // pred p(in String) {}
     // pred q {


### PR DESCRIPTION
closes #10 

Previously, a predicate could be defined multiple times. The first definition (in textual order) would win out, but if multiple predicates were called `main` then the last one (in textual order) would be the entry point to the program.

This mod prevents predicates from being defined multiple times, using logic very similar to that used to prevent multiple definitions of the same type.